### PR TITLE
Update nunjucks version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,10 @@ describe("nunjucks example test", function () {
         template = nunjucks.compile('<div class="{{ thing }}"></div>');
     })
 
-    it('Thing has class', function (done) {
-        template.render({thing: "something"}, function (err, result) {
-            document.body.innerHTML += result;
-            expect(document.querySelector('.something')).to.exist;
-            done();
-        });
+    it('Thing has class', function () {
+        var result = template.render({thing: "something"});
+        document.body.innerHTML += result;
+        expect(document.querySelector('.something')).to.exist;
     });;    
 });
 
@@ -56,12 +54,10 @@ describe("nunjucks example test", function () {
         template = env.getPreprocessedTemplate('index.html');
     })
 
-    it('Thing has class', function (done) {
-        template.render({thing: "something"}, function (err, result) {
-            document.body.innerHTML += result;
-            expect(document.querySelector('.something')).to.exist;
-            done();
-        });
+    it('Thing has class', function () {
+        var result = template.render({thing: "something"});
+        document.body.innerHTML += result;
+        expect(document.querySelector('.something')).to.exist;
     });
 
     it('Thing has widget class', function () {

--- a/README.md
+++ b/README.md
@@ -27,13 +27,16 @@ describe("nunjucks example test", function () {
     var template;
 
     before(function () {
-        template = nunjucks.compile('<div class=".thing"> {{ thing }} </div>');
+        template = nunjucks.compile('<div class="{{ thing }}"></div>');
     })
 
-    it('Thing has class', function () {
-        var $el = $(template.render({thing: "something"}));
-        expect($el.is('.thing')).to.be.true;
-    });;
+    it('Thing has class', function (done) {
+        template.render({thing: "something"}, function (err, result) {
+            document.body.innerHTML += result;
+            expect(document.querySelector('.something')).to.exist;
+            done();
+        });
+    });;    
 });
 
 ```
@@ -53,10 +56,12 @@ describe("nunjucks example test", function () {
         template = env.getPreprocessedTemplate('index.html');
     })
 
-    it('Thing has class', function () {
-        var $el = $(template.render({}));
-        var thing = new Thing($el);
-        expect($el.is('.thing')).to.be.true;
+    it('Thing has class', function (done) {
+        template.render({thing: "something"}, function (err, result) {
+            document.body.innerHTML += result;
+            expect(document.querySelector('.something')).to.exist;
+            done();
+        });
     });
 
     it('Thing has widget class', function () {

--- a/adapter.js
+++ b/adapter.js
@@ -1,10 +1,12 @@
 (function(window) {
 
   window.nunjucks.Environment.prototype.getPreprocessedTemplate = function (path) {
-    if (window.__html__[path]) {
-      return nunjucks.compile(window.__html__[path], this);
-    } else {
+    if (!window.__html__) {
+      throw new Error('html2js preprocessor is required for template files');
+    } else if (!window.__html__[path]) {
       throw new Error('nunjucks template does not exist');
+    } else {
+      return nunjucks.compile(window.__html__[path], this);
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "repository": "https://github.com/TakenPilot/karma-nunjucks",
   "peerDependencies": {
     "karma": ">=0.12.8",
-    "nunjucks": "^1.0.7"
+    "nunjucks": "^2.0.0"
   },
   "devDependencies": {
     "blanket": "^1.1.6",
@@ -31,6 +31,6 @@
     "jsdom": "^1.0.0-pre.7",
     "mocha": "^1.21.4",
     "mocha-lcov-reporter": "0.0.1",
-    "nunjucks": "^1.0.7"
+    "nunjucks": "^2.0.0"
   }
 }

--- a/test/adapter.test.js
+++ b/test/adapter.test.js
@@ -27,6 +27,11 @@ describe('Nunjucks for Karma Adapter', function () {
     });
   });
 
+  it('should throw exception when preprocessor has not been run', function () {
+    window.__html__ = void 0;
+    expect(function() { env.getPreprocessedTemplate('test') }).to.throw(Error);
+  });
+
   it('should throw exception for template that does not exist', function () {
     window.__html__ = {};
     expect(function() { env.getPreprocessedTemplate('test') }).to.throw(Error);


### PR DESCRIPTION
This PR updates the nunjucks version, adds an error to `getPreprocessedTemplate`, and makes the examples in the readme work out of the box.
